### PR TITLE
 add LZC and SHIFT function

### DIFF
--- a/sv-examples/test_LZC_output/LZC_21.sv
+++ b/sv-examples/test_LZC_output/LZC_21.sv
@@ -1,0 +1,47 @@
+
+        
+
+        
+/* verilator lint_off WIDTH */        
+module LZC_21 
+   (
+   input logic [20:0] data_in,
+   output logic [4:0] zero_num,
+   output logic  is_zero
+   );
+
+   logic [31:0] val32;
+   logic [5:0] tmp_cnt;
+   logic [15:0] val16;
+   logic [7:0] val8;
+   logic [3:0] val4;
+   logic [1:0] val2;
+   logic  val1;
+   logic [5:0] tmp_zero_num;
+
+  assign val32 = {11'd0,data_in};
+always_comb
+   begin
+      if(data_in[20:0] == 21'd0) begin
+        is_zero = 1'b1;
+        tmp_cnt = 6'd32;
+      end else begin
+        is_zero = 1'b0;
+        tmp_cnt[5] = 1'b0;
+        tmp_cnt[4] = (val32[31:16] == 16'd0);
+        val16 = tmp_cnt[4] ? val32[15:0] : val32[31:16];
+        tmp_cnt[3] = (val16[15:8] == 8'd0);
+        val8 = tmp_cnt[3] ? val16[7:0] : val16[15:8];
+        tmp_cnt[2] = (val8[7:4] == 4'd0);
+        val4 = tmp_cnt[2] ? val8[3:0] : val8[7:4];
+        tmp_cnt[1] = (val4[3:2] == 2'd0);
+        val2 = tmp_cnt[1] ? val4[1:0] : val4[3:2];
+        tmp_cnt[0] = (val2[1:1] == 1'd0);
+      end
+    end
+  assign tmp_zero_num = tmp_cnt - 6'd11;
+  assign zero_num = tmp_zero_num[4:0];
+
+
+endmodule
+/* verilator lint_on WIDTH */        

--- a/sv-examples/test_LZC_output/LZC_28.sv
+++ b/sv-examples/test_LZC_output/LZC_28.sv
@@ -1,0 +1,47 @@
+
+        
+
+        
+/* verilator lint_off WIDTH */        
+module LZC_28 
+   (
+   input logic [27:0] data_in,
+   output logic [4:0] zero_num,
+   output logic  is_zero
+   );
+
+   logic [31:0] val32;
+   logic [5:0] tmp_cnt;
+   logic [15:0] val16;
+   logic [7:0] val8;
+   logic [3:0] val4;
+   logic [1:0] val2;
+   logic  val1;
+   logic [5:0] tmp_zero_num;
+
+  assign val32 = {4'd0,data_in};
+always_comb
+   begin
+      if(data_in[27:0] == 28'd0) begin
+        is_zero = 1'b1;
+        tmp_cnt = 6'd32;
+      end else begin
+        is_zero = 1'b0;
+        tmp_cnt[5] = 1'b0;
+        tmp_cnt[4] = (val32[31:16] == 16'd0);
+        val16 = tmp_cnt[4] ? val32[15:0] : val32[31:16];
+        tmp_cnt[3] = (val16[15:8] == 8'd0);
+        val8 = tmp_cnt[3] ? val16[7:0] : val16[15:8];
+        tmp_cnt[2] = (val8[7:4] == 4'd0);
+        val4 = tmp_cnt[2] ? val8[3:0] : val8[7:4];
+        tmp_cnt[1] = (val4[3:2] == 2'd0);
+        val2 = tmp_cnt[1] ? val4[1:0] : val4[3:2];
+        tmp_cnt[0] = (val2[1:1] == 1'd0);
+      end
+    end
+  assign tmp_zero_num = tmp_cnt - 6'd4;
+  assign zero_num = tmp_zero_num[4:0];
+
+
+endmodule
+/* verilator lint_on WIDTH */        

--- a/sv-examples/test_LZC_output/LZC_64.sv
+++ b/sv-examples/test_LZC_output/LZC_64.sv
@@ -1,0 +1,48 @@
+
+        
+
+        
+/* verilator lint_off WIDTH */        
+module LZC_64 
+   (
+   input logic [63:0] data_in,
+   output logic [6:0] zero_num,
+   output logic  is_zero
+   );
+
+   logic [63:0] val64;
+   logic [6:0] tmp_cnt;
+   logic [31:0] val32;
+   logic [15:0] val16;
+   logic [7:0] val8;
+   logic [3:0] val4;
+   logic [1:0] val2;
+   logic  val1;
+
+  assign val64 = data_in;
+always_comb
+   begin
+      if(data_in[63:0] == 64'd0) begin
+        is_zero = 1'b1;
+        tmp_cnt = 7'd64;
+      end else begin
+        is_zero = 1'b0;
+        tmp_cnt[6] = 1'b0;
+        tmp_cnt[5] = (val64[63:32] == 32'd0);
+        val32 = tmp_cnt[5] ? val64[31:0] : val64[63:32];
+        tmp_cnt[4] = (val32[31:16] == 16'd0);
+        val16 = tmp_cnt[4] ? val32[15:0] : val32[31:16];
+        tmp_cnt[3] = (val16[15:8] == 8'd0);
+        val8 = tmp_cnt[3] ? val16[7:0] : val16[15:8];
+        tmp_cnt[2] = (val8[7:4] == 4'd0);
+        val4 = tmp_cnt[2] ? val8[3:0] : val8[7:4];
+        tmp_cnt[1] = (val4[3:2] == 2'd0);
+        val2 = tmp_cnt[1] ? val4[1:0] : val4[3:2];
+        tmp_cnt[0] = (val2[1:1] == 1'd0);
+      end
+    end
+  assign zero_num = tmp_cnt;
+
+
+endmodule
+/* verilator lint_on WIDTH */        

--- a/sv-examples/test_shift_output/shift_16_left_5_unsigned.sv
+++ b/sv-examples/test_shift_output/shift_16_left_5_unsigned.sv
@@ -1,0 +1,18 @@
+
+        
+
+        
+/* verilator lint_off WIDTH */        
+module shift_16_left_5_unsigned 
+   (
+   input logic [15:0] data_in,
+   output logic [20:0] data_out
+   );
+
+   
+
+  assign data_out = {data_in,{5{1'b0}}};
+
+
+endmodule
+/* verilator lint_on WIDTH */        

--- a/sv-examples/test_shift_output/shift_16_right_5_signed.sv
+++ b/sv-examples/test_shift_output/shift_16_right_5_signed.sv
@@ -1,0 +1,18 @@
+
+        
+
+        
+/* verilator lint_off WIDTH */        
+module shift_16_right_5_signed 
+   (
+   input logic [15:0] data_in,
+   output logic [15:0] data_out
+   );
+
+   
+
+  assign data_out = {{5{data_in[15]}},data_in[15:5]};
+
+
+endmodule
+/* verilator lint_on WIDTH */        

--- a/sv-examples/test_shift_output/shift_16_right_5_unsigned.sv
+++ b/sv-examples/test_shift_output/shift_16_right_5_unsigned.sv
@@ -1,0 +1,18 @@
+
+        
+
+        
+/* verilator lint_off WIDTH */        
+module shift_16_right_5_unsigned 
+   (
+   input logic [15:0] data_in,
+   output logic [15:0] data_out
+   );
+
+   
+
+  assign data_out = {{5{1'b0}},data_in[15:5]};
+
+
+endmodule
+/* verilator lint_on WIDTH */        

--- a/sv-examples/test_shift_output/shift_5_right_3_unsigned.sv
+++ b/sv-examples/test_shift_output/shift_5_right_3_unsigned.sv
@@ -1,0 +1,18 @@
+
+        
+
+        
+/* verilator lint_off WIDTH */        
+module shift_5_right_3_unsigned 
+   (
+   input logic [4:0] data_in,
+   output logic [4:0] data_out
+   );
+
+   
+
+  assign data_out = {{3{1'b0}},data_in[4:3]};
+
+
+endmodule
+/* verilator lint_on WIDTH */        

--- a/ts/src/modules/LZC.ts
+++ b/ts/src/modules/LZC.ts
@@ -1,0 +1,94 @@
+/*
+* Using dichotomy to calculate the number of leading zeros for data with arbitrary bit width
+*
+*/
+import { Module, type TSSVParameters, type IntRange, Expr } from 'tssv/lib/core/TSSV'
+
+/**
+ * configuration parameters of the LZC module
+ */
+export interface LZC_Parameters extends TSSVParameters {
+  /**
+     * bit width of LZC data
+     */
+  dataWidth: IntRange<1, 256>
+}
+
+export class LZC extends Module {
+  declare params: LZC_Parameters
+  constructor (params: LZC_Parameters) {
+    super({
+      // define the default parameter values
+      name: params.name,
+      dataWidth: params.dataWidth
+    })
+
+    // calculate counter width based on dataWidth
+    let cnt_width = this.bitWidth(this.params.dataWidth)
+
+    // ============================================IO define start===========================================
+    // define IO signals
+    this.IOs = {
+      data_in: { direction: 'input', width: this.params.dataWidth },
+      zero_num: { direction: 'output', width: cnt_width },
+      is_zero: { direction: 'output' }
+    }
+
+    // width and depth check
+    if (this.params.dataWidth <= 0) console.log('Error: dataWidth should be greater than 0')
+
+    // ===========================================IO define end==============================================
+    let padding_num = 0
+    let tmp_val_width = this.params.dataWidth
+    if (Math.log2(this.params.dataWidth) % 1 !== 0) { // If it is not a power of 2, perform padding processing
+      while (Math.log2(tmp_val_width) % 1 !== 0) {
+        tmp_val_width++
+        padding_num++
+      }
+      this.addSignal(`val${tmp_val_width}`, { width: tmp_val_width })
+      this.addAssign({ in: new Expr(`{${padding_num}'d0,data_in}`), out: `val${tmp_val_width}` })
+      cnt_width++
+    } else {
+      this.addSignal(`val${tmp_val_width}`, { width: tmp_val_width })
+      this.addAssign({ in: new Expr('data_in'), out: `val${tmp_val_width}` })
+    }
+
+    this.addSignal('tmp_cnt', { width: cnt_width })
+
+    let cnt_body = ''
+    for (let i = cnt_width - 2; i >= 0; i--) {
+      if (i >= 0) {
+        tmp_val_width = tmp_val_width / 2
+        const tmp_cnt_logic = `tmp_cnt[${i}] = (val${tmp_val_width * 2}[${tmp_val_width * 2 - 1}:${tmp_val_width}] == ${tmp_val_width}'d0);`
+        this.addSignal(`val${tmp_val_width}`, { width: tmp_val_width })
+        const tmp_val_logic = `val${tmp_val_width} = tmp_cnt[${i}] ? val${tmp_val_width * 2}[${tmp_val_width - 1}:0] : val${tmp_val_width * 2}[${tmp_val_width * 2 - 1}:${tmp_val_width}];`
+        if (i > 0) {
+          cnt_body += `        ${tmp_cnt_logic}\n        ${tmp_val_logic}\n`
+        } else {
+          cnt_body += `        ${tmp_cnt_logic}`
+        }
+      }
+    }
+
+    const CombAlwaysBody =
+`   begin
+      if(data_in[${this.params.dataWidth - 1}:0] == ${this.params.dataWidth}'d0) begin
+        is_zero = 1'b1;
+        tmp_cnt = ${cnt_width}'d${this.params.dataWidth + padding_num};
+      end else begin
+        is_zero = 1'b0;
+        tmp_cnt[${cnt_width - 1}] = 1'b0;
+${cnt_body}
+      end
+    end
+`
+    this.addCombAlways({ outputs: ['tmp_cnt', 'is_zero'] }, CombAlwaysBody)
+    if (Math.log2(this.params.dataWidth) % 1 !== 0) {
+      this.addSignal('tmp_zero_num', { width: cnt_width })
+      this.addAssign({ in: new Expr(`tmp_cnt - ${cnt_width}'d${padding_num}`), out: 'tmp_zero_num' })
+      this.addAssign({ in: new Expr(`tmp_zero_num[${cnt_width - 2}:0]`), out: 'zero_num' })
+    } else {
+      this.addAssign({ in: new Expr('tmp_cnt'), out: 'zero_num' })
+    }
+  }
+}

--- a/ts/src/modules/shift.ts
+++ b/ts/src/modules/shift.ts
@@ -1,0 +1,68 @@
+/*
+* Module for generating left or right shift of input data
+* To the left, fill the low bit with 0, and expand the output data bit width accordingly
+* To the right, if it is a signed number, fill the sign bit with the high bit, and if it is an unsigned number, fill the high bit with 0. Truncate the low bit and keep the bit width unchanged
+*/
+import { Module, type TSSVParameters, type IntRange, Expr } from 'tssv/lib/core/TSSV'
+
+/**
+ * configuration parameters of the shift module
+ */
+export interface shift_Parameters extends TSSVParameters {
+  /**
+     * bit width of shift data
+     */
+  dataWidth: IntRange<1, 256>
+  /**
+     * Select shift direction, left or right
+     */
+  shift_direct?: 'left' | 'right'
+  /**
+     * Shift length
+     */
+  shift_val: IntRange<1, 256>
+  /**
+     * Indicate whether the input data is a signed number
+     */
+  isSigned?: 'signed' | 'unsigned'
+}
+
+export class shift extends Module {
+  declare params: shift_Parameters
+  constructor (params: shift_Parameters) {
+    super({
+      // define the default parameter values
+      name: params.name,
+      dataWidth: params.dataWidth,
+      shift_direct: params.shift_direct || 'right',
+      shift_val: params.shift_val,
+      isSigned: params.isSigned || 'unsigned'
+    })
+
+    // calculate output width
+    let output_width = this.params.dataWidth
+    if (this.params.shift_direct === 'left') {
+      output_width = this.params.dataWidth + this.params.shift_val
+    }
+
+    // ============================================IO define start===========================================
+    // define IO signals
+    this.IOs = {
+      data_in: { direction: 'input', width: this.params.dataWidth },
+      data_out: { direction: 'output', width: output_width }
+    }
+
+    // width and depth check
+    if (this.params.dataWidth <= 0) console.log('Error: dataWidth should be greater than 0')
+
+    if (this.params.shift_direct === 'left') {
+      this.addAssign({ in: new Expr(`{data_in,{${this.params.shift_val}{1'b0}}}`), out: 'data_out' })
+    } else {
+      if (this.params.isSigned === 'signed') {
+        this.addAssign({ in: new Expr(`{{${this.params.shift_val}{data_in[${this.params.dataWidth - 1}]}},data_in[${this.params.dataWidth - 1}:${this.params.shift_val}]}`), out: 'data_out' })
+      } else {
+        this.addAssign({ in: new Expr(`{{${this.params.shift_val}{1'b0}},data_in[${this.params.dataWidth - 1}:${this.params.shift_val}]}`), out: 'data_out' })
+      }
+    }
+  }
+}

--- a/ts/test/modules/test_LZC.ts
+++ b/ts/test/modules/test_LZC.ts
@@ -1,0 +1,29 @@
+import { LZC } from 'tssv/lib/modules/LZC'
+import { writeFileSync } from 'fs'
+
+// ============================================test1=======================================================
+console.log('test1')
+const test_1 = new LZC({ dataWidth: 64 })
+try {
+  writeFileSync(`sv-examples/test_LZC_output/${test_1.name}.sv`, test_1.writeSystemVerilog())
+} catch (err) {
+  console.error(err)
+}
+
+// ============================================test2=======================================================
+console.log('test2')
+const test_2 = new LZC({ dataWidth: 28 })
+try {
+  writeFileSync(`sv-examples/test_LZC_output/${test_2.name}.sv`, test_2.writeSystemVerilog())
+} catch (err) {
+  console.error(err)
+}
+
+// ============================================test3=======================================================
+console.log('test3')
+const test_3 = new LZC({ dataWidth: 21 })
+try {
+  writeFileSync(`sv-examples/test_LZC_output/${test_3.name}.sv`, test_3.writeSystemVerilog())
+} catch (err) {
+  console.error(err)
+}

--- a/ts/test/modules/test_shift.ts
+++ b/ts/test/modules/test_shift.ts
@@ -1,0 +1,38 @@
+import { shift } from 'tssv/lib/modules/shift'
+import { writeFileSync } from 'fs'
+
+// ============================================test1=======================================================
+console.log('test1')
+const test_1 = new shift({ dataWidth: 16, shift_val: 5 })
+try {
+  writeFileSync(`sv-examples/test_shift_output/${test_1.name}.sv`, test_1.writeSystemVerilog())
+} catch (err) {
+  console.error(err)
+}
+
+// ============================================test2=======================================================
+console.log('test2')
+const test_2 = new shift({ dataWidth: 16, shift_direct: 'left', shift_val: 5 })
+try {
+  writeFileSync(`sv-examples/test_shift_output/${test_2.name}.sv`, test_2.writeSystemVerilog())
+} catch (err) {
+  console.error(err)
+}
+
+// ============================================test3=======================================================
+console.log('test3')
+const test_3 = new shift({ dataWidth: 5, shift_direct: 'right', shift_val: 3 })
+try {
+  writeFileSync(`sv-examples/test_shift_output/${test_3.name}.sv`, test_3.writeSystemVerilog())
+} catch (err) {
+  console.error(err)
+}
+
+// ============================================test4=======================================================
+console.log('test4')
+const test_4 = new shift({ dataWidth: 16, shift_val: 5, shift_direct: 'right', isSigned: 'signed' })
+try {
+  writeFileSync(`sv-examples/test_shift_output/${test_4.name}.sv`, test_4.writeSystemVerilog())
+} catch (err) {
+  console.error(err)
+}


### PR DESCRIPTION
* add leading_zero_count function
LZC.ts      Its functions are as follows：
"Detect the number of leading zeros for any bit-width data. Use the binary search method for detection. For data with a bit width less than a power of 2, first pad zeros to the higher bits to reach a power of 2, and then subtract the number of padded zeros after detection to obtain the actual number of leading zeros in the data."

* add shift function
shift.ts      Its functions are as follows：
"Module for generating left or right shift of input data.
To the left, fill the low bit with 0, and expand the output data bit width accordingly.
To the right, if it is a signed number, fill the sign bit with the high bit, and if it is an unsigned number, fill the high bit with 0. Truncate the low bit and keep the bit width unchanged."